### PR TITLE
feat: ログインページをAPI連携(ログインページの色を変更)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,27 +1,86 @@
-import Link from 'next/link';
-import { FaLaptopCode } from 'react-icons/fa';
-import LoginButton from '../../../shared/components/atoms/LoginButton';
-import InputForm from '../../../shared/components/atoms/InputForm';
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { FaLaptopCode } from 'react-icons/fa'
+import LoginButton from '../../../shared/components/atoms/LoginButton'
+import InputForm from '../../../shared/components/atoms/InputForm'
 
 export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email,
+          password,
+        }),
+      })
+
+      if (!res.ok) {
+        setError('ログインに失敗しました')
+        return
+      }
+
+      // 成功したらトップページへ
+      router.push('/')
+      router.refresh()
+    } catch (err) {
+      setError('ログインに失敗しました')
+    }
+  }
+
   return (
     <div className="flex items-center justify-center p-20 max-h-screen">
-      <div className="bg-gradient-to-r from-cyan-400 to-cyan-500 px-16 py-24 text-center w-full  max-w-md rounded-md">
+      <div className="bg-gradient-to-r from-rose-300 to-cyan-400 px-16 py-24 text-center w-full max-w-md rounded-md">
         <h1 className="text-2xl flex items-center text-white font-bold">
           <FaLaptopCode />
           テックブログ共有アプリ
         </h1>
         <h2 className="text-xl text-white font-bold mt-3">ログイン</h2>
-        <form className="flex flex-col gap-5 text-left">
+
+        {error && (
+          <div className="w-full rounded-md bg-rose-200 border-rose-300 text-rose-800 px-4 py-2 text-sm text-center shadow-sm">
+            ログインに失敗しました
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5 text-left mt-5">
           <div>
             <p className="font-bold mb-3">メールアドレス</p>
-            <InputForm name="email" placeholder="メールアドレス" />
+            <InputForm
+              type="email"
+              placeholder="メールアドレス"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
           </div>
           <div>
             <p className="font-bold mb-3">パスワード</p>
-            <InputForm type="password" placeholder="パスワード" />
+            <InputForm
+              type="password"
+              placeholder="パスワード"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
           </div>
-          <LoginButton>ログイン</LoginButton>
+          <LoginButton>
+            ログイン
+          </LoginButton>
           <Link
             href="/signup"
             className="text-center underline mt-5 hover:text-cyan-800"
@@ -31,5 +90,5 @@ export default function LoginPage() {
         </form>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/70#issue-3554317490

### ログイン成功
- Email: test@example.com
- Password: password123
を入力

以下の画面に遷移

<img width="1440" height="782" alt="スクリーンショット 2025-10-27 21 37 08" src="https://github.com/user-attachments/assets/70305d44-1dec-422d-a1ef-d8fc028477e7" />

### ログイン失敗
アドレスとパスワードを間違えた時
<img width="1428" height="761" alt="スクリーンショット 2025-10-27 21 28 35" src="https://github.com/user-attachments/assets/6d631815-bd51-422f-9043-34876f33867e" />

### 何もフォームに表示しない時
ComponentProps<'input'> を使っているので、すでに value, onChange, required などが使える状態なので、
InputFormの修正は不要です！

<img width="1439" height="773" alt="スクリーンショット 2025-10-27 21 30 19" src="https://github.com/user-attachments/assets/9dbd7481-956b-49bc-a2ab-e11bbe1e2f4e" />
