### PR TITLE
style:  atomsのボタンコンポーネントのrounded-lgをrounded-fullにする

### DIFF
--- a/src/shared/components/atoms/ArticleReturnButton.tsx
+++ b/src/shared/components/atoms/ArticleReturnButton.tsx
@@ -12,7 +12,7 @@ export default function ArticleReturnButton({ children, ...props }: PropsType) {
   return (
     <button
         onClick={()=> router.push('/articles')}
-        className="w-[20%] bg-amber-500 text-white  font-semibold rounded-lg p-5 mt-5 hover:bg-amber-400"
+        className="w-[20%] bg-amber-500 text-white  font-semibold rounded-full p-5 mt-5 hover:bg-amber-400"
         {...props}
     >
         {children}

--- a/src/shared/components/atoms/LoginButton.tsx
+++ b/src/shared/components/atoms/LoginButton.tsx
@@ -9,7 +9,7 @@ type PropsType = {
 export default function LoginButton({ children, ...props }: PropsType) {
   return (
     <button
-      className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 shadow hover:bg-emerald-500 transition"
+      className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-full font-bold py-3 mt-5 shadow hover:bg-emerald-500 transition"
       {...props}
     >
       {children}

--- a/src/shared/components/atoms/ReturnButton.tsx
+++ b/src/shared/components/atoms/ReturnButton.tsx
@@ -12,7 +12,7 @@ export default function SignupButton({ children, ...props }: PropsType) {
   return (
     <button
         onClick={()=> router.push('/')}
-        className="w-[20%] bg-amber-500 text-white  font-semibold rounded-lg p-5 mt-5 hover:bg-amber-400"
+        className="w-[20%] bg-amber-500 text-white  font-semibold rounded-full p-5 mt-5 hover:bg-amber-400"
         {...props}
     >
         {children}

--- a/src/shared/components/atoms/SignupButton.tsx
+++ b/src/shared/components/atoms/SignupButton.tsx
@@ -9,7 +9,7 @@ type PropsType = {
 export default function SignupButton({ children, ...props }: PropsType) {
   return (
     <button
-      className="bg-amber-500 text-white  font-bold rounded-lg p-5 mt-5 hover:bg-amber-400"
+      className="bg-amber-500 text-white  font-bold rounded-full p-5 mt-5 hover:bg-amber-400"
       {...props}
     >
       {children}

--- a/src/shared/components/atoms/SignupLeadButton.tsx
+++ b/src/shared/components/atoms/SignupLeadButton.tsx
@@ -7,7 +7,7 @@ type PropsType = {
 export default function SignupButton({ children, ...props }: PropsType) {
   return (
     <button
-      className="w-full bg-amber-500 hover:bg-amber-400 text-white rounded-lg font-bold py-3 mt-5 shadow hover:shadow-lg transition"
+      className="w-full bg-amber-500 hover:bg-amber-400 text-white rounded-full font-bold py-3 mt-5 shadow hover:shadow-lg transition"
       {...props}
     >
       {children}


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/88#issue-3564437656

<img width="1438" height="772" alt="スクリーンショット 2025-10-29 19 13 52" src="https://github.com/user-attachments/assets/59736157-226f-4dda-9df1-cf0e36b80602" />

<img width="1435" height="763" alt="スクリーンショット 2025-10-29 19 14 07" src="https://github.com/user-attachments/assets/8a86134f-bd94-46a0-a8b3-60ff5588ec3d" />

<img width="1433" height="774" alt="スクリーンショット 2025-10-29 19 14 29" src="https://github.com/user-attachments/assets/e0ca75db-0cef-41ca-a6b5-431a32339f44" />

<img width="1433" height="764" alt="スクリーンショット 2025-10-29 19 14 51" src="https://github.com/user-attachments/assets/b152ff8b-2744-4f6e-ba7d-721fe84e5734" />

<img width="1430" height="786" alt="スクリーンショット 2025-10-29 19 15 13" src="https://github.com/user-attachments/assets/f36ce3a5-1495-46cc-bad7-08424e37d309" />




