### PR TITLE
feat: ユーザー設定を実装するためのセッション管理の実装(ユーザーの設定つまり編集や削除のための実装)

### DIFF
--- a/src/app/api/auth/me/route.tsx
+++ b/src/app/api/auth/me/route.tsx
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+
+export async function GET() {
+  try {
+    const user = await getSession()
+    
+    if (!user) {
+      return NextResponse.json(
+        { message: '認証されていません' },
+        { status: 401 }
+      )
+    }
+    
+    return NextResponse.json({ user })
+  } catch (error) {
+    console.error('セッション取得エラー:', error)
+    return NextResponse.json(
+      { message: 'セッション取得に失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers'
+import { verifyToken } from './jwt'
+import { prisma } from './prisma'
+
+export async function getSession() {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('token')?.value
+
+  if (!token) {
+    return null
+  }
+
+  const payload = await verifyToken(token)
+  
+  if (!payload) {
+    return null
+  }
+  
+  const user = await prisma.user.findUnique({
+    where: { id: payload.userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      image: true,
+      createdAt: true,
+    },
+  })
+  
+  return user
+}
+
+// ログインが必須の場合に使う
+export async function requireAuth() {
+  const user = await getSession()
+  
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+  
+  return user
+}


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/95#issue-3566044982

### 実装できたこと
- getSession() が正しく動作
- Cookieからトークンを取得
- JWTを検証
- ユーザー情報をデータベースから取得
- /api/auth/me エンドポイントが動作

### エンドポイント(ログイン中)
http://localhost:3000/api/auth/me

<img width="1440" height="716" alt="スクリーンショット 2025-10-30 0 35 42" src="https://github.com/user-attachments/assets/2634b2e7-f3b6-4615-8c2c-9a8a7dfa7934" />

### 未ログイン
<img width="1434" height="730" alt="スクリーンショット 2025-10-30 0 36 57" src="https://github.com/user-attachments/assets/6b8b456b-a693-4638-b140-fe93c4d9041f" />
