### PR TITLE
fix: ユーザー詳細のページにdropdownから入れるようにする

### DIFF
--- a/src/features/articles/components/UserDropdown.tsx
+++ b/src/features/articles/components/UserDropdown.tsx
@@ -34,7 +34,7 @@ export function UserDropdown({ userId, userName }: Props) {
             </li>
             <li>
               <Link
-                href="/settings"
+                href="/settings/profile"
                 className="block px-4 py-2 hover:bg-gray-100"
                 onClick={() => setIsOpen(false)}
               >


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/pull/171#issue-3781362532
<img width="1419" height="770" alt="スクリーンショット 2026-01-07 0 22 27" src="https://github.com/user-attachments/assets/723ddf95-19b3-468d-9fc2-9e180e52f83d" />
