### PR TITLE
fix: 記事のページのバリデーションメッセージの修正(バリデーションエラーの解消)

### DIFF
--- a/src/app/(articles)/articles/new/page.tsx
+++ b/src/app/(articles)/articles/new/page.tsx
@@ -7,16 +7,22 @@ import {
   MarkdownEditor,
 } from '@/features/articles/components';
 
+type FieldErrors = {
+  title?: string;
+  content?: string;
+  tags?: string;
+};
+
 export default function NewArticlePage() {
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [tags, setTags] = useState('');
   const [body, setBody] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState('');
+  const [errors, setErrors] = useState<FieldErrors>({});
 
   const handlePublish = async () => {
-    setError('');
+    setErrors({});
     setIsSubmitting(true);
 
     try {
@@ -45,16 +51,24 @@ export default function NewArticlePage() {
 
       if (!res.ok) {
         const data = await res.json();
-        setError(data.message || '投稿に失敗しました');
+
+        if (data.errors && Array.isArray(data.errors)) {
+          const fieldErrors: FieldErrors = {};
+          data.errors.forEach((err: { path: string[]; message: string }) => {
+            const field = err.path[0] as keyof FieldErrors;
+            if (field && !fieldErrors[field]) {
+              fieldErrors[field] = err.message;
+            }
+          });
+          setErrors(fieldErrors);
+        }
         return;
       }
-
-      // 成功したら記事一覧へ
       router.push('/articles');
       router.refresh();
     } catch (err) {
       console.error('投稿エラー:', err);
-      setError('投稿に失敗しました');
+      setErrors({ title: '投稿に失敗しました' });
     } finally {
       setIsSubmitting(false);
     }
@@ -63,11 +77,11 @@ export default function NewArticlePage() {
   return (
     <div className="flex flex-col min-h-screen bg-gray-100">
       <NewArticleHeader onPublish={handlePublish} isSubmitting={isSubmitting} />
-      {error && (
+      {/* {error && (
         <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 mx-5 mt-2 rounded">
           {error}
         </div>
-      )}
+      )} */}
       <main className="grow container mx-auto px-5 py-5 pt-1">
         <MarkdownEditor
           title={title}
@@ -76,6 +90,7 @@ export default function NewArticlePage() {
           onTagsChange={setTags}
           body={body}
           onBodyChange={setBody}
+          errors={errors}
         />
       </main>
     </div>

--- a/src/features/articles/components/MarkdownEditor.tsx
+++ b/src/features/articles/components/MarkdownEditor.tsx
@@ -6,6 +6,12 @@ import { MarkdownPreview } from '@/shared/components/molecules/MarkdownPreview';
 
 type TabType = 'edit' | 'preview' | 'split';
 
+type FieldErrors = {
+  title?: string;
+  content?: string;
+  tags?: string;
+};
+
 type Props = {
   title: string;
   onTitleChange: (value: string) => void;
@@ -13,6 +19,7 @@ type Props = {
   onTagsChange: (value: string) => void;
   body: string;
   onBodyChange: (value: string) => void;
+  errors?: FieldErrors;
 };
 
 const TABS: { key: TabType; label: string }[] = [
@@ -28,23 +35,41 @@ export function MarkdownEditor({
   onTagsChange,
   body,
   onBodyChange,
+  errors = {},
 }: Props) {
   const [activeTab, setActiveTab] = useState<TabType>('edit');
 
   return (
     <>
-      <input
-        value={title}
-        onChange={(e) => onTitleChange(e.target.value)}
-        placeholder="タイトルを入力してください"
-        className="w-full text-2xl font-semibold border border-slate-200 rounded-md p-3 mb-3 focus:outline-none bg-white"
-      />
-      <input
-        value={tags}
-        onChange={(e) => onTagsChange(e.target.value)}
-        placeholder="タグを入力してください。スペース区切りで5つまで入力できます。"
-        className="w-full border border-slate-200 rounded-md p-2 text-base focus:outline-none bg-white"
-      />
+      {/* タイトル */}
+      <div className="mb-3">
+        <input
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          placeholder="タイトルを入力してください"
+          className={`w-full text-2xl font-semibold border rounded-md p-3 focus:outline-none bg-white ${
+            errors.title ? 'border-red-500' : 'border-slate-200'
+          }`}
+        />
+        {errors.title && (
+          <p className="text-red-500 text-sm mt-1">{errors.title}</p>
+        )}
+      </div>
+
+      {/* タグ */}
+      <div className="mb-3">
+        <input
+          value={tags}
+          onChange={(e) => onTagsChange(e.target.value)}
+          placeholder="タグを入力してください。スペース区切りで5つまで入力できます。"
+          className={`w-full border rounded-md p-2 text-base focus:outline-none bg-white ${
+            errors.tags ? 'border-red-500' : 'border-slate-200'
+          }`}
+        />
+        {errors.tags && (
+          <p className="text-red-500 text-sm mt-1">{errors.tags}</p>
+        )}
+      </div>
 
       {/* タブナビゲーション */}
       <div className="flex items-center gap-2 mb-2 border-b border-slate-200 pb-2">
@@ -61,13 +86,20 @@ export function MarkdownEditor({
         </span>
       </div>
 
+      {/* 本文エラー */}
+      {errors.content && (
+        <p className="text-red-500 text-sm mb-2">{errors.content}</p>
+      )}
+
       {/* 編集モード */}
       {activeTab === 'edit' && (
         <textarea
           value={body}
           onChange={(e) => onBodyChange(e.target.value)}
           placeholder="エンジニアに関わる知識をMarkdown記法で書いて共有しよう"
-          className="w-full min-h-[600px] p-4 border border-slate-200 rounded-md text-base leading-7 bg-white focus:outline-none"
+          className={`w-full min-h-[600px] p-4 border rounded-md text-base leading-7 bg-white focus:outline-none ${
+            errors.content ? 'border-red-500' : 'border-slate-200'
+          }`}
         />
       )}
 
@@ -85,7 +117,9 @@ export function MarkdownEditor({
             value={body}
             onChange={(e) => onBodyChange(e.target.value)}
             aria-label="エディター"
-            className="min-h-[600px] p-4 border border-slate-200 rounded-md font-mono leading-7 bg-white focus:outline-none"
+            className={`min-h-[600px] p-4 border rounded-md font-mono leading-7 bg-white focus:outline-none ${
+              errors.content ? 'border-red-500' : 'border-slate-200'
+            }`}
           />
           <div className="min-h-[600px] p-6 border border-slate-200 rounded-md bg-white overflow-auto">
             <MarkdownPreview content={body} />


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/57#issue-3548578495

<img width="1385" height="762" alt="スクリーンショット 2026-01-11 4 56 27" src="https://github.com/user-attachments/assets/dc122026-6d98-446e-8cdc-e8078d7a4d0c" />

<img width="1406" height="778" alt="スクリーンショット 2026-01-11 4 57 34" src="https://github.com/user-attachments/assets/6f8540

<img width="1381" height="787" alt="スクリーンショット 2026-01-11 5 09 38" src="https://github.com/user-attachments/assets/a14bd9de-30a1-457c-88ef-763895c7567f" />
c1-683f-41f6-8a83-0e9121d7270d" />


