### PR TITLE
fix: バリデーションのメッセージを変更(記事関連)

### DIFF
--- a/src/shared/lib/validations/article.ts
+++ b/src/shared/lib/validations/article.ts
@@ -4,12 +4,12 @@ export const createArticleSchema = z.object({
   title: z
     .string()
     .min(1, 'タイトルを入力してください')
-    .max(100, 'タイトルは100文字以内です'),
+    .max(100, 'タイトルは100文字以内にしてください'),
   content: z.string().min(1, '本文を入力してください'),
   tags: z
     .array(z.string())
-    .min(1, 'タグを1つ以上入力してください')
-    .max(5, 'タグは5つまでです'),
+    .min(1, 'タグは1つ以上指定してください')
+    .max(5, 'タグは5つ以内にしてください'),
   /*
    *未指定の場合は空配列にする（タグを必須にしない場合）
    *.default([]),


### PR DESCRIPTION
<img width="1438" height="776" alt="スクリーンショット 2026-01-12 1 13 50" src="https://github.com/user-attachments/assets/90d9e7a1-bb20-456d-a3b0-2c0bf48e56c3" />
