### PR TITLE
refactor: 記事編集ページのリファクタリング

### DIFF
--- a/src/app/(articles)/articles/[id]/edit/page.tsx
+++ b/src/app/(articles)/articles/[id]/edit/page.tsx
@@ -23,25 +23,19 @@ export default function ArticleEditPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [errors, setErrors] = useState<FieldErrors>({});
 
-  // 記事データを取得
   useEffect(() => {
     const fetchArticle = async () => {
-      try {
-        const res = await fetch(`/api/articles/${id}`);
-        if (!res.ok) {
-          setErrors({ title: '記事が見つかりません' });
-          return;
-        }
-        const article = await res.json();
-        setTitle(article.title);
-        setTags(article.tags.join(' '));
-        setBody(article.content);
-      } catch (err) {
-        console.error('記事取得エラー:', err);
-        setErrors({ title: '記事の取得に失敗しました' });
-      } finally {
+      const res = await fetch(`/api/articles/${id}`);
+      if (!res.ok) {
+        setErrors({ title: '記事が見つかりません' });
         setIsLoading(false);
+        return;
       }
+      const article = await res.json();
+      setTitle(article.title);
+      setTags(article.tags.join(' '));
+      setBody(article.content);
+      setIsLoading(false);
     };
 
     fetchArticle();
@@ -51,54 +45,46 @@ export default function ArticleEditPage() {
     setErrors({});
     setIsSubmitting(true);
 
-    try {
-      /**
-       * タグ文字列を配列に変換
-       * trim(): 前後の空白を削除
-       * split(/\s+/): 1つ以上の空白で分割
-       * filter(): 空文字を除去
-       */
-      const tagArray = tags
-        .trim()
-        .split(/\s+/)
-        .filter((tag) => tag.length > 0);
+    /**
+     * タグ文字列を配列に変換
+     * trim(): 前後の空白を削除
+     * split(/\s+/): 1つ以上の空白で分割
+     * filter(): 空文字を除去
+     */
+    const tagArray = tags
+      .trim()
+      .split(/\s+/)
+      .filter((tag) => tag.length > 0);
 
-      const res = await fetch(`/api/articles/${id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          title,
-          content: body,
-          tags: tagArray,
-        }),
-      });
+    const res = await fetch(`/api/articles/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title,
+        content: body,
+        tags: tagArray,
+      }),
+    });
 
-      if (!res.ok) {
-        const data = await res.json();
+    const data = await res.json();
+    setIsSubmitting(false);
 
-        if (data.errors && Array.isArray(data.errors)) {
-          const fieldErrors: FieldErrors = {};
-          data.errors.forEach((err: { path: string[]; message: string }) => {
-            const field = err.path[0] as keyof FieldErrors;
-            if (field && !fieldErrors[field]) {
-              fieldErrors[field] = err.message;
-            }
-          });
-          setErrors(fieldErrors);
-        }
-        return;
+    if (!res.ok) {
+      if (data.errors && Array.isArray(data.errors)) {
+        const fieldErrors: FieldErrors = {};
+        data.errors.forEach((err: { path: string[]; message: string }) => {
+          const field = err.path[0] as keyof FieldErrors;
+          if (field && !fieldErrors[field]) {
+            fieldErrors[field] = err.message;
+          }
+        });
+        setErrors(fieldErrors);
       }
-
-      router.push(`/articles/${id}`);
-      router.refresh();
-    } catch (err) {
-      console.error('更新エラー:', err);
-      setErrors({ title: '更新に失敗しました' });
-    } finally {
-      setIsSubmitting(false);
+      return;
     }
+
+    router.push(`/articles/${id}`);
+    router.refresh();
   };
 
   if (isLoading) {
@@ -112,7 +98,10 @@ export default function ArticleEditPage() {
   return (
     <div className="flex flex-col min-h-screen bg-gray-100">
       <header className="bg-linear-to-r from-cyan-500 to-cyan-600 px-5 py-4 flex justify-between items-center">
-        <Link href={`/articles/${id}`} className="text-white hover:underline">
+        <Link
+          href={`/articles/${id}`}
+          className="text-white font-bold text-xl hover:underline"
+        >
           ← 戻る
         </Link>
         <h1 className="text-2xl font-bold text-white">記事を編集</h1>
@@ -124,13 +113,6 @@ export default function ArticleEditPage() {
           {isSubmitting ? '更新中...' : '更新する'}
         </button>
       </header>
-
-      {/* {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 mx-5 mt-2 rounded">
-          {error}
-        </div>
-      )} */}
-
       <main className="grow container mx-auto px-5 py-5">
         <MarkdownEditor
           title={title}


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/188#issue-3801657314

React-hook-formやzodは不要。
理由は以下の3点
- API側でZodバリデーションが動いている
- エラーはAPIから返ってきて表示される
- new/page.tsx と同じ構造で一貫性がある

<img width="1434" height="768" alt="スクリーンショット 2026-01-12 2 47 12" src="https://github.com/user-attachments/assets/4fe14c05-0b92-4cac-814d-7952f636ab33" />

<img width="1435" height="773" alt="スクリーンショット 2026-01-12 2 47 30" src="https://github.com/user-attachments/assets/30e80662-9cf7-48c1-97e7-7d83708eab77" />
