### PR TITLE
feat: DB スキーマ（Like モデル）追加

### DIFF
--- a/prisma/migrations/20260119152135_add_like_model/migration.sql
+++ b/prisma/migrations/20260119152135_add_like_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "articleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_articleId_key" ON "Like"("userId", "articleId");
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,22 +6,20 @@ datasource db {
   provider = "postgresql"
 }
 
-// NextAuth.js用のモデル
 model Account {
   id                String  @id @default(cuid())
   userId            String
   type              String
   provider          String
   providerAccountId String
-  refresh_token     String? @db.Text
-  access_token      String? @db.Text
+  refresh_token     String?
+  access_token      String?
   expires_at        Int?
   token_type        String?
   scope             String?
-  id_token          String? @db.Text
+  id_token          String?
   session_state     String?
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
 }
@@ -43,10 +41,10 @@ model User {
   password      String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
-
-  accounts Account[]
-  sessions Session[]
-  articles Article[]
+  accounts      Account[]
+  articles      Article[]
+  likes         Like[]
+  sessions      Session[]
 }
 
 model VerificationToken {
@@ -57,18 +55,29 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
-// アプリ用のモデル
 model Article {
   id        String   @id @default(cuid())
   title     String
-  content   String   @db.Text
+  content   String
   tags      String[]
-  isDraft Boolean @default(false)
+  isDraft   Boolean  @default(false)
   authorId  String
-  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
   likeCount Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  likes     Like[]
 
   @@index([authorId])
+}
+
+model Like {
+  id        String   @id @default(cuid())
+  userId    String
+  articleId String
+  createdAt DateTime @default(now())
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, articleId])
 }


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/158#issue-3770278918

### タスク1: DB スキーマ（Like モデル）
- schema.prisma 修正( Like モデル追加)

- マイグレーション実行
```
npx prisma migrate dev --name add_like_model
```
- Prisma Client 再生成
```
npx prisma generate
```

- ポイント

|項目 | 説明|
|-- | --|
|@@unique([userId, articleId]) | 1ユーザー1記事につき1いいね|
|onDelete: Cascade | ユーザー or 記事削除時に Like も削除|
|likeCount | 既存フィールド。API で更新する|