### PR TITLE
chore: OAuthButotnをコンポーネント化(カタログ化はしない)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,10 +5,11 @@ import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
-import { FaLaptopCode, FaGithub } from 'react-icons/fa';
+import { FaLaptopCode } from 'react-icons/fa';
 import { signIn } from 'next-auth/react';
 import { Button } from '@/shared/components/atoms/Button';
 import { InputForm } from '@/shared/components/atoms/InputForm';
+import { OAuthButton } from '@/shared/components/atoms/OAuthButton';
 import { loginSchema, LoginInput } from '@/shared/lib/validations/auth';
 
 export default function LoginPage() {
@@ -40,11 +41,6 @@ export default function LoginPage() {
 
     router.push('/articles');
     router.refresh();
-  };
-
-  // GitHub ログイン
-  const handleGitHubSignIn = () => {
-    signIn('github', { callbackUrl: '/articles' });
   };
 
   return (
@@ -106,14 +102,7 @@ export default function LoginPage() {
         </div>
 
         {/* GitHub ログインボタン */}
-        <button
-          type="button"
-          onClick={handleGitHubSignIn}
-          className="flex items-center justify-center gap-2 w-full bg-gray-900 text-white py-3 rounded-full hover:bg-gray-800 transition font-bold"
-        >
-          <FaGithub className="text-xl" />
-          GitHubでログイン
-        </button>
+        <OAuthButton provider="github" mode="login" />
 
         <Link
           href="/signup"

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -5,10 +5,11 @@ import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
-import { FaLaptopCode, FaGithub } from 'react-icons/fa';
+import { FaLaptopCode } from 'react-icons/fa';
 import { signIn } from 'next-auth/react';
 import { InputForm } from '@/shared/components/atoms/InputForm';
 import { Button } from '@/shared/components/atoms/Button';
+import { OAuthButton } from '@/shared/components/atoms/OAuthButton';
 import { signupSchema, SignUpInput } from '@/shared/lib/validations/auth';
 
 export default function SignUpPage() {
@@ -54,11 +55,6 @@ export default function SignUpPage() {
 
     router.push('/articles');
     router.refresh();
-  };
-
-  // GitHub で登録
-  const handleGitHubSignIn = () => {
-    signIn('github', { callbackUrl: '/articles' });
   };
 
   return (
@@ -131,14 +127,7 @@ export default function SignUpPage() {
         </div>
 
         {/* GitHub 登録ボタン */}
-        <button
-          type="button"
-          onClick={handleGitHubSignIn}
-          className="flex items-center justify-center gap-2 w-full bg-gray-900 text-white py-3 rounded-full hover:bg-gray-800 transition font-bold"
-        >
-          <FaGithub className="text-xl" />
-          GitHubで登録
-        </button>
+        <OAuthButton provider="github" mode="signup" />
 
         <Link
           href="/login"

--- a/src/shared/components/atoms/OAuthButton/OAuthButton.tsx
+++ b/src/shared/components/atoms/OAuthButton/OAuthButton.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import { FaGithub } from 'react-icons/fa';
+
+type Provider = 'github' | 'google';
+
+type Props = {
+  provider: Provider;
+  mode?: 'login' | 'signup';
+  callbackUrl?: string;
+};
+
+const providerConfig = {
+  github: {
+    icon: FaGithub,
+    label: 'GitHub',
+    className: 'bg-gray-900 text-white hover:bg-gray-800',
+  },
+};
+
+export function OAuthButton({
+  provider,
+  mode = 'login',
+  callbackUrl = '/articles',
+}: Props) {
+  const config = providerConfig[provider];
+  const actionText = mode === 'login' ? 'ログイン' : '登録';
+
+  const handleClick = () => {
+    signIn(provider, { callbackUrl });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`flex items-center justify-center gap-2 w-full py-3 rounded-full transition font-bold ${config.className}`}
+    >
+      <config.icon className="text-xl" />
+      {config.label}で{actionText}
+    </button>
+  );
+}

--- a/src/shared/components/atoms/OAuthButton/OAuthButton.tsx
+++ b/src/shared/components/atoms/OAuthButton/OAuthButton.tsx
@@ -3,7 +3,7 @@
 import { signIn } from 'next-auth/react';
 import { FaGithub } from 'react-icons/fa';
 
-type Provider = 'github' | 'google';
+type Provider = 'github';
 
 type Props = {
   provider: Provider;

--- a/src/shared/components/atoms/OAuthButton/index.tsx
+++ b/src/shared/components/atoms/OAuthButton/index.tsx
@@ -1,0 +1,1 @@
+export { OAuthButton } from './OAuthButton';


### PR DESCRIPTION
## 概要

ログイン・新規登録ページで重複していたGitHub OAuthボタンのインライン実装を、共通コンポーネント `OAuthButton` として切り出した。
将来的に他のOAuthプロバイダー（Google等）を追加する際も、`providerConfig` に追記するだけで対応できる設計にした。

また、Storybookのバージョンアップ作業を楽にするため、Dependabot自動更新とCIビルドチェックを整備した。

## 変更内容

### OAuthButton コンポーネント化
- `OAuthButton` コンポーネントを新規作成（`src/shared/components/atoms/OAuthButton/`）
  - `provider`・`mode`（login / signup）・`callbackUrl` を props で受け取る
  - プロバイダーごとのアイコン・ラベル・スタイルは `providerConfig` で一元管理
- ログインページの GitHub ボタンを `<OAuthButton provider="github" mode="login" />` に置き換え
- 新規登録ページの GitHub ボタンを `<OAuthButton provider="github" mode="signup" />` に置き換え

### Storybook バージョンアップ対策
- `.github/dependabot.yml` を追加 — `@storybook/*` 関連パッケージを毎週月曜にグループPRとして自動作成
- CI に `storybook` ジョブを追加 — PRのたびに `build-storybook` を実行しビルドエラーを自動検知

## テスト方法

- [ ] ログインページで「GitHubでログイン」ボタンが表示される
- [ ] 新規登録ページで「GitHubで登録」ボタンが表示される
- [ ] それぞれのボタンをクリックすると GitHub 認証フローに遷移する
- [ ] ログイン・登録後に `/articles` にリダイレクトされる
- [ ] CI の `storybook` ジョブが通ることを確認する