### PR TITLE
test: E2Eテスト(認証)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { createTestUser, signup, login } from './helpers/auth';
+
+test.describe('認証フロー', () => {
+  test('新規登録できる', async ({ page }) => {
+    const user = createTestUser();
+    await signup(page, user);
+
+    // サインアップページから離れたことを確認
+    await expect(page).not.toHaveURL('/signup');
+  });
+
+  test('ログインできる', async ({ page }) => {
+    // 1. まず登録
+    const user = createTestUser();
+    await signup(page, user);
+
+    // 2. ログアウト（セッションクリア）
+    await page.context().clearCookies();
+
+    // 3. ログイン
+    await login(page, user);
+
+    // ログインページから離れた
+    await expect(page).not.toHaveURL('/login');
+  });
+
+  test('不正な認証情報でエラーが表示される', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByPlaceholder('メールアドレス').fill('notexist@example.com');
+    await page.getByPlaceholder('パスワード').fill('wrongpassword');
+
+    await page
+      .locator('button[type="submit"]')
+      .filter({ hasText: 'ログイン' })
+      .click();
+
+    await expect(
+      page.getByText('メールアドレスまたはパスワードが間違っています'),
+    ).toBeVisible();
+  });
+});

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('トップページが表示される', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
-  await expect(page).toHaveTitle(/.*/);
-});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,132 @@
+import { Page } from '@playwright/test';
+
+/**
+ * テストユーザーの型定義
+ */
+export interface TestUser {
+  email: string;
+  password: string;
+  name?: string;
+}
+
+/**
+ * デフォルトのテストユーザー
+ */
+export const testUsers = {
+  valid: {
+    email: 'test@example.com',
+    password: 'Test1234!',
+    name: 'テストユーザー',
+  },
+  newUser: {
+    email: `test-${Date.now()}@example.com`,
+    password: 'Test1234!',
+    name: 'New Test User',
+  },
+} as const;
+
+/**
+ * ユニークなテストユーザーを生成する
+ */
+export function createTestUser(baseName = 'テストユーザー'): TestUser {
+  return {
+    name: baseName,
+    email: `test-${Date.now()}-${Math.random().toString(36).substring(7)}@example.com`,
+    password: 'Test1234!',
+  };
+}
+
+/**
+ * ログインする
+ */
+export async function login(page: Page, user: TestUser) {
+  await page.goto('/login');
+  await page.getByPlaceholder('メールアドレス').fill(user.email);
+  await page.getByPlaceholder('パスワード').fill(user.password);
+
+  // 「ログイン」ボタンをtype="submit"で特定
+  await page
+    .locator('button[type="submit"]')
+    .filter({ hasText: 'ログイン' })
+    .click();
+
+  // ログイン成功を待つ（URLが変わるまで待機）
+  await page.waitForURL((url) => url.pathname !== '/login', { timeout: 10000 });
+}
+
+/**
+ * ログアウトする
+ */
+export async function logout(page: Page) {
+  // ユーザーメニューを開く
+  await page.click('[data-testid="user-menu"]');
+  await page.click('text=ログアウト');
+}
+
+/**
+ * 新規ユーザーを登録する
+ */
+export async function signup(page: Page, user: TestUser) {
+  await page.goto('/signup');
+  if (user.name) {
+    await page.getByPlaceholder('例)山田太郎(ニックネーム可)').fill(user.name);
+  }
+  await page.getByPlaceholder('メールアドレス').fill(user.email);
+  await page.getByPlaceholder('パスワード').fill(user.password);
+
+  // 「新規登録」ボタンをtype="submit"で特定
+  await page
+    .locator('button[type="submit"]')
+    .filter({ hasText: '新規登録' })
+    .click();
+
+  // 登録成功を待つ（URLが変わるまで待機、タイムアウトを長めに）
+  await page.waitForURL((url) => url.pathname !== '/signup', {
+    timeout: 10000,
+  });
+}
+
+/**
+ * ログイン状態を確認する
+ */
+export async function isLoggedIn(page: Page): Promise<boolean> {
+  try {
+    await page.waitForSelector('[data-testid="user-menu"]', { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * バリデーションエラーメッセージを取得する
+ */
+export async function getValidationError(
+  page: Page,
+  fieldName: string,
+): Promise<string | null> {
+  const errorSelector = `[data-testid="error-${fieldName}"]`;
+  try {
+    await page.waitForSelector(errorSelector, { timeout: 3000 });
+    return await page.textContent(errorSelector);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * トーストメッセージを取得する
+ */
+export async function getToastMessage(page: Page): Promise<string | null> {
+  try {
+    const toast = await page.waitForSelector(
+      '[role="alert"], [data-testid="toast"]',
+      {
+        timeout: 5000,
+      },
+    );
+    return await toast.textContent();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/199#issue-3808649042

### 3つのテスト
✅新規登録できる - ユーザー登録の成功パス
✅ ログインできる - ログインの成功パス
✅ 不正な認証情報でエラーが表示される - ログインの失敗パス（エラーハンドリング）

ログアウトは今回はパス。

```
npm run test:e2e
```
<img width="915" height="225" alt="スクリーンショット 2026-02-14 0 19 05" src="https://github.com/user-attachments/assets/17b3a6e1-6199-4ab1-85ae-46e6241c8be1" />

```
npx playwright show-report
```
<img width="1196" height="511" alt="スクリーンショット 2026-02-14 0 19 44" src="https://github.com/user-attachments/assets/b4a1686f-4fdc-4f22-9790-70245153fcaa" />

```
npm run test:e2e:ui
```
<img width="1276" height="802" alt="スクリーンショット 2026-02-14 0 22 01" src="https://github.com/user-attachments/assets/3a27b29f-a8e3-444a-885e-cfb5c43005b8" />

- テスト実行

<img width="253" height="275" alt="スクリーンショット 2026-02-14 0 22 43" src="https://github.com/user-attachments/assets/9319a1db-3225-4aa5-9bae-7e866ea09fce" />

<img width="251" height="264" alt="スクリーンショット 2026-02-14 0 24 26" src="https://github.com/user-attachments/assets/79f5cdee-4b11-403a-983b-325b666d46b6" />

- 各テストを実行
```
# 1つ目だけ実行
npx playwright test -g "新規登録できる"

# 2つ目だけ実行
npx playwright test -g "ログインできる"

# 3つ目だけ実行
npx playwright test -g "不正な認証情報"
```

