### PR TITLE
refactor: データフェッチをTanStack Queryに統一

### DIFF
--- a/src/app/(neutral)/reset-password/page.tsx
+++ b/src/app/(neutral)/reset-password/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, Suspense } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -24,8 +25,6 @@ function ResetPasswordForm() {
 
   const [serverError, setServerError] = useState('');
   const [isSuccess, setIsSuccess] = useState(false);
-  const [isValidating, setIsValidating] = useState(true);
-  const [isTokenValid, setIsTokenValid] = useState(false);
 
   const {
     register,
@@ -33,63 +32,44 @@ function ResetPasswordForm() {
     formState: { errors, isSubmitting },
   } = useForm<ResetPasswordInput>({
     resolver: zodResolver(resetPasswordSchema),
-    defaultValues: {
-      token: token || '',
-    },
+    defaultValues: { token: token || '' },
   });
 
-  // トークンの有効性を確認
-  useEffect(() => {
-    const validateToken = async () => {
-      if (!token) {
-        setIsValidating(false);
-        setIsTokenValid(false);
-        return;
-      }
+  const { isLoading: isValidating, data: tokenData } = useQuery({
+    queryKey: ['resetToken', token],
+    queryFn: async () => {
+      if (!token) return { valid: false };
+      return validateResetTokenAction({ token });
+    },
+    staleTime: Infinity,
+    retry: false,
+  });
 
-      try {
-        const result = await validateResetTokenAction({ token });
-        setIsTokenValid(result.valid);
-      } catch (err) {
-        console.error('トークン検証エラー:', err);
-        setIsTokenValid(false);
-      } finally {
-        setIsValidating(false);
-      }
-    };
+  const isTokenValid = tokenData?.valid ?? false;
 
-    validateToken();
-  }, [token]);
-
-  const onSubmit = async (data: ResetPasswordInput) => {
-    setServerError('');
-
-    try {
-      const result = await resetPasswordAction({
-        token: data.token,
-        password: data.password,
-      });
-
+  const { mutate: submitReset, isPending } = useMutation({
+    mutationFn: (data: ResetPasswordInput) =>
+      resetPasswordAction({ token: data.token, password: data.password }),
+    onSuccess: (result) => {
       if (!result.success) {
         setServerError(result.error ?? 'エラーが発生しました');
         return;
       }
-
       setIsSuccess(true);
-
-      // 3秒後にログインページへリダイレクト
-      setTimeout(() => {
-        router.push('/login');
-      }, 3000);
-    } catch (err) {
-      console.error('パスワードリセットエラー:', err);
+      setTimeout(() => router.push('/login'), 3000);
+    },
+    onError: () => {
       setServerError(
         'エラーが発生しました。しばらく経ってからお試しください。',
       );
-    }
+    },
+  });
+
+  const onSubmit = (data: ResetPasswordInput) => {
+    setServerError('');
+    submitReset(data);
   };
 
-  // ローディング中
   if (isValidating) {
     return (
       <div className="flex items-center justify-center p-20 max-h-screen">
@@ -104,7 +84,6 @@ function ResetPasswordForm() {
     );
   }
 
-  // トークンが無効な場合
   if (!isTokenValid) {
     return (
       <div className="flex items-center justify-center p-20 max-h-screen">
@@ -114,12 +93,10 @@ function ResetPasswordForm() {
             テックブログ共有アプリ
           </h1>
           <h2 className="text-xl text-white font-bold mt-3">無効なリンク</h2>
-
           <div className="w-full rounded-md bg-rose-200 border-rose-300 text-rose-800 px-4 py-3 text-sm text-center shadow-sm mt-5">
             このパスワードリセットリンクは無効または期限切れです。
             再度パスワードリセットをリクエストしてください。
           </div>
-
           <Link href="/forgot-password" className="block mt-5">
             <Button variant="primary">パスワードリセットをリクエスト</Button>
           </Link>
@@ -128,7 +105,6 @@ function ResetPasswordForm() {
     );
   }
 
-  // 成功画面
   if (isSuccess) {
     return (
       <div className="flex items-center justify-center p-20 max-h-screen">
@@ -140,15 +116,12 @@ function ResetPasswordForm() {
           <h2 className="text-xl text-white font-bold mt-3">
             パスワード変更完了
           </h2>
-
           <div className="w-full rounded-md bg-green-200 border-green-300 text-green-800 px-4 py-3 text-sm text-center shadow-sm mt-5">
             パスワードを変更しました。新しいパスワードでログインできます。
           </div>
-
           <p className="text-white text-sm mt-5">
             自動的にログインページへ移動します...
           </p>
-
           <Link
             href="/login"
             className="block text-center underline mt-5 hover:text-cyan-800"
@@ -160,7 +133,6 @@ function ResetPasswordForm() {
     );
   }
 
-  // パスワード入力フォーム
   return (
     <div className="flex items-center justify-center p-20 max-h-screen">
       <div className="bg-linear-to-r from-rose-300 to-cyan-400 px-16 py-24 text-center w-full max-w-md rounded-md">
@@ -171,23 +143,19 @@ function ResetPasswordForm() {
         <h2 className="text-xl text-white font-bold mt-3">
           新しいパスワードを設定
         </h2>
-
         <p className="text-white text-sm mt-3">
           安全な新しいパスワードを入力してください。
         </p>
-
         {serverError && (
           <div className="w-full rounded-md bg-rose-200 border-rose-300 text-rose-800 px-4 py-2 text-sm text-center shadow-sm mt-3">
             {serverError}
           </div>
         )}
-
         <form
           onSubmit={handleSubmit(onSubmit)}
           className="flex flex-col gap-5 text-left mt-5"
         >
           <input type="hidden" {...register('token')} />
-
           <div>
             <p className="font-bold mb-3">新しいパスワード</p>
             <InputForm
@@ -201,7 +169,6 @@ function ResetPasswordForm() {
               </p>
             )}
           </div>
-
           <div>
             <p className="font-bold mb-3">パスワード（確認）</p>
             <InputForm
@@ -215,12 +182,14 @@ function ResetPasswordForm() {
               </p>
             )}
           </div>
-
-          <Button type="submit" variant="primary" disabled={isSubmitting}>
-            {isSubmitting ? '変更中...' : 'パスワードを変更'}
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={isSubmitting || isPending}
+          >
+            {isPending ? '変更中...' : 'パスワードを変更'}
           </Button>
         </form>
-
         <Link
           href="/login"
           className="block text-center underline mt-5 hover:text-cyan-800"
@@ -232,7 +201,6 @@ function ResetPasswordForm() {
   );
 }
 
-// Suspenseでラップ（useSearchParamsのため）
 export default function ResetPasswordPage() {
   return (
     <Suspense

--- a/src/features/notifications/components/NotificationBell/NotificationBell.tsx
+++ b/src/features/notifications/components/NotificationBell/NotificationBell.tsx
@@ -37,7 +37,7 @@ export function NotificationBell() {
             <h3 className="font-bold text-gray-800">通知</h3>
             {unreadCount > 0 && (
               <button
-                onClick={markAllAsRead}
+                onClick={() => markAllAsRead()}
                 className="text-xs text-cyan-600 hover:text-cyan-800"
               >
                 全て既読にする

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDropdown } from '@/shared/hooks';
 import { NotificationWithRelations } from '@/types';
 import {
@@ -9,49 +9,54 @@ import {
   markNotificationAsReadAction,
 } from '@/features/notifications/actions/notification.action';
 
+export const notificationKeys = {
+  all: ['notifications'] as const,
+  list: () => [...notificationKeys.all, 'list'] as const,
+};
+
 export function useNotifications() {
   const { isOpen, ref, toggle, close } = useDropdown();
-  const [notifications, setNotifications] = useState<
-    NotificationWithRelations[]
-  >([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const queryClient = useQueryClient();
 
-  const fetchNotifications = async () => {
-    setIsLoading(true);
-    try {
+  const { data: notifications = [], isLoading } = useQuery({
+    queryKey: notificationKeys.list(),
+    queryFn: async (): Promise<NotificationWithRelations[]> => {
       const result = await listNotificationsAction();
-      if (result.success) {
-        setNotifications(result.notifications as NotificationWithRelations[]);
-      }
-    } catch (error) {
-      console.error('通知取得エラー:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      if (!result.success) return [];
+      return result.notifications as NotificationWithRelations[];
+    },
+    staleTime: 1 * 60 * 1000,
+  });
 
-  useEffect(() => {
-    fetchNotifications();
-  }, []);
-
-  const markAllAsRead = async () => {
-    const result = await markAllNotificationsAsReadAction();
-    if (result.success) {
-      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-    }
-  };
-
-  const markAsRead = async (notificationId: string) => {
-    const result = await markNotificationAsReadAction({ notificationId });
-    if (result.success) {
-      setNotifications((prev) =>
-        prev.map((n) => (n.id === notificationId ? { ...n, isRead: true } : n)),
+  const { mutate: markAllAsRead } = useMutation({
+    mutationFn: markAllNotificationsAsReadAction,
+    onSuccess: () => {
+      queryClient.setQueryData(
+        notificationKeys.list(),
+        (prev: NotificationWithRelations[] = []) =>
+          prev.map((n) => ({ ...n, isRead: true })),
       );
-    }
-  };
+    },
+  });
+
+  const { mutate: markAsRead } = useMutation({
+    mutationFn: (notificationId: string) =>
+      markNotificationAsReadAction({ notificationId }),
+    onSuccess: (_, notificationId) => {
+      queryClient.setQueryData(
+        notificationKeys.list(),
+        (prev: NotificationWithRelations[] = []) =>
+          prev.map((n) =>
+            n.id === notificationId ? { ...n, isRead: true } : n,
+          ),
+      );
+    },
+  });
 
   const handleToggle = () => {
-    if (!isOpen) fetchNotifications();
+    if (!isOpen) {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.list() });
+    }
     toggle();
   };
 


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/333#issue-3958364695

https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/327#issue-3913132900

## 概要
データフェッチをTanStack Queryに統一。

## 変更内容
動作確認済み

### useNotifications
- useState + useEffect → useQuery + useMutation に移行
- キャッシュが効くためベルを開くたびの無駄なリクエストを削減
- 既読処理をsetQueryDataで楽観的に更新

### reset-password
- useEffect + useState → useQuery + useMutation に移行
- トークン検証をuseQueryで管理
- パスワードリセット処理をuseMutationで管理