### PR TITLE
refactor: パスワードリセットのバリデーションをexternalのdtoに1本化

### DIFF
--- a/src/external/dto/auth/auth.dto.ts
+++ b/src/external/dto/auth/auth.dto.ts
@@ -46,6 +46,15 @@ export const resetPasswordSchema = z
     path: ['confirmPassword'],
   });
 
+export const resetPasswordServerSchema = z.object({
+  token: z.string().min(1, 'トークンが必要です'),
+  password: z
+    .string()
+    .min(1, 'パスワードを入力してください')
+    .min(8, 'パスワードは8文字以上にしてください')
+    .max(50, 'パスワードは50文字以内にしてください'),
+});
+
 export type SignUpInput = z.infer<typeof signupSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
 export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;

--- a/src/external/handler/auth/mutation.server.ts
+++ b/src/external/handler/auth/mutation.server.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import { userRepository } from '@/external/repository/user';
 import { passwordResetTokenRepository } from '@/external/repository/auth';
 import { sendPasswordResetEmail } from '@/external/email';
-import { signupSchema } from '@/external/dto/auth';
+import { signupSchema, resetPasswordServerSchema } from '@/external/dto/auth';
 
 const TOKEN_EXPIRY_HOURS = 1;
 
@@ -84,25 +84,13 @@ export async function validateResetTokenHandler({ token }: { token: string }) {
   return { valid: true as const };
 }
 
-export async function resetPasswordHandler({
-  token,
-  password,
-}: {
-  token: string;
-  password: string;
-}) {
-  if (password.length < 8) {
-    return {
-      success: false as const,
-      error: 'パスワードは8文字以上で入力してください',
-    };
+export async function resetPasswordHandler(body: unknown) {
+  const parsed = resetPasswordServerSchema.safeParse(body);
+  if (!parsed.success) {
+    return { success: false as const, errors: parsed.error.issues };
   }
-  if (password.length > 50) {
-    return {
-      success: false as const,
-      error: 'パスワードは50文字以内で入力してください',
-    };
-  }
+
+  const { token, password } = parsed.data;
 
   const resetToken = await passwordResetTokenRepository.findByToken(token);
   if (!resetToken) {


### PR DESCRIPTION
# このタスクの続き

https://github.com/Hashimoto-Noriaki/next-article-share-app/pull/363#issue-4212376026

