### PR TITLE
chore: ESLintルールでアーキテクチャ違反を防ぐ(Server Actionsはclient/hooksでのみ利用可)

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -3,4 +3,5 @@
 
 module.exports = {
   'restrict-service-imports': require('./src/eslint-local-rules/restrict-service-imports'),
+  'restrict-action-imports': require('./src/eslint-local-rules/restrict-action-imports'),
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ const eslintConfig = [
     },
     rules: {
       'local-rules/restrict-service-imports': 'error',
+      'local-rules/restrict-action-imports': 'error',
     },
   },
 ];

--- a/src/eslint-local-rules/restrict-action-imports.js
+++ b/src/eslint-local-rules/restrict-action-imports.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Server Actions（features/{feature}/actions/）は
+// client層（features/{feature}/hooks/, features/{feature}/components/client/,
+//          shared/hooks/, 'use client' ディレクティブを持つファイル）
+// からのみ import を許可する。
+//
+// 正しい依存方向:
+//   components/client, hooks
+//     → features/{feature}/actions  (Server Actions)
+//       → external/handler
+//         → external/repository
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Server Actions（features/*/actions）は client層（hooks / components/client / "use client" ファイル）からのみ import できます。',
+    },
+    schema: [],
+    messages: {
+      noActionImport:
+        '"{{importPath}}" は Server Action です。import できるのは hooks/, components/client/, または "use client" ディレクティブを持つファイルのみです。',
+    },
+  },
+
+  create(context) {
+    const filePath = context.getFilename();
+
+    const ACTION_IMPORT_PATTERN = /^@\/features\/[^/]+\/actions\//;
+
+    const ALLOWED_FILE_PATTERNS = [
+      /\/features\/[^/]+\/hooks\//,
+      /\/features\/[^/]+\/components\/client\//,
+      /\/shared\/hooks\//,
+    ];
+
+    const isAllowedByPath = ALLOWED_FILE_PATTERNS.some((pattern) =>
+      pattern.test(filePath),
+    );
+
+    // Program は ImportDeclaration より先に訪問されるため、
+    // ここで 'use client' を検出してフラグを立てる
+    let hasUseClientDirective = false;
+
+    return {
+      Program(node) {
+        hasUseClientDirective = node.body.some(
+          (statement) =>
+            statement.type === 'ExpressionStatement' &&
+            statement.expression.type === 'Literal' &&
+            statement.expression.value === 'use client',
+        );
+      },
+
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        if (!ACTION_IMPORT_PATTERN.test(importPath)) {
+          return;
+        }
+
+        if (isAllowedByPath || hasUseClientDirective) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'noActionImport',
+          data: { importPath },
+        });
+      },
+    };
+  },
+};

--- a/src/eslint-local-rules/restrict-action-imports.js
+++ b/src/eslint-local-rules/restrict-action-imports.js
@@ -27,7 +27,7 @@ module.exports = {
   },
 
   create(context) {
-    const filePath = context.getFilename();
+    const filePath = context.filename ?? context.getFilename();
 
     const ACTION_IMPORT_PATTERN = /^@\/features\/[^/]+\/actions\//;
 

--- a/src/eslint-local-rules/restrict-service-imports.js
+++ b/src/eslint-local-rules/restrict-service-imports.js
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   create(context) {
-    const filePath = context.getFilename();
+    const filePath = context.filename ?? context.getFilename();
 
     const CLIENT_LAYER_PATTERN =
       /\/features\/[^/]+\/(?:hooks|components\/client)\//;


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/393#issue-4270912947

### 理由
***Server Component から actionsを直接呼ぶと、認証・バリデーションが保証されなくなるリスク***があるからです。

### 責務の分離
```
Server Component  → データ取得（fetch / Prisma 直接）
 Client Component  → ユーザー操作への応答（actions 経由）
```

  ### Server Component が actions を呼ぶと：
  - 二重責務 — データ取得と書き込みトリガーが同じ層に混在する
  - 意図が不明瞭 — 「なぜ Server Component が mutationを呼んでいるのか」がわかりにくくなる
  - 副作用の追跡が困難 — どこから actions が呼ばれているか grep しにくくなる

  actions は「ユーザーの操作に応じた副作用」を担う層なので、操作を受け取る
  client/hooks からのみ呼ばれる、という一貫したルールになっている。