### PR TITLE
fix: .docsをdocsに変更した実装の残り

### DIFF
--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 export const getApiDocs = (): Record<string, unknown> => {
-  const filePath = path.join(process.cwd(), '.docs', 'api', 'openapi.yaml');
+  const filePath = path.join(process.cwd(), 'docs', 'api', 'openapi.yaml');
   const fileContents = fs.readFileSync(filePath, 'utf8');
   const spec = yaml.load(fileContents) as Record<string, unknown>;
   return spec;


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/347#issue-4126410919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * APIドキュメントの読み込み処理を改善しました。OpenAPI仕様ファイルの参照パスを修正し、ドキュメント取得がより確実に機能するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->