### PR TITLE
chore: TAKTワークフロー導入

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,10 +12,23 @@
       "Bash(git diff:*)",
       "Bash(git status)",
       "Bash(git commit:*)",
+      "Bash(takt *)",
       "Read",
       "Grep",
       "Glob"
     ],
-    "deny": ["Read(.env)", "Read(.env.*)"]
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git push * --force)",
+      "Bash(git push * -f)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(rm -rf*)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Write(.env)",
+      "Write(.env.*)"
+    ]
   }
 }

--- a/.takt/.gitignore
+++ b/.takt/.gitignore
@@ -1,0 +1,23 @@
+# Ignore everything by default
+*
+
+# This file itself
+!.gitignore
+
+# Project configuration
+!config.yaml
+
+# Facets and workflows (version-controlled)
+!workflows/
+!workflows/**
+!facets/
+!facets/personas/
+!facets/personas/**
+!facets/policies/
+!facets/policies/**
+!facets/knowledge/
+!facets/knowledge/**
+!facets/instructions/
+!facets/instructions/**
+!facets/output-contracts/
+!facets/output-contracts/**

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,0 +1,3 @@
+provider: claude
+model: claude-sonnet-4-6
+language: ja

--- a/.takt/workflows/default.yaml
+++ b/.takt/workflows/default.yaml
@@ -1,0 +1,100 @@
+name: default
+description: Test-first development workflow (plan -> write tests -> draft (implement + AI self-review) -> peer-review (3 parallel) -> COMPLETE).
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 30
+initial_step: plan
+steps:
+  - name: plan
+    edit: false
+    persona: planner
+    knowledge: architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+          - WebSearch
+          - WebFetch
+    rules:
+      - condition: Requirements are clear and implementable
+        next: write_tests
+      - condition: User is asking a question (not an implementation task)
+        next: COMPLETE
+      - condition: Requirements unclear, insufficient info
+        next: ABORT
+        appendix: |
+          Clarifications needed:
+          - {Question 1}
+          - {Question 2}
+    instruction: plan
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+  - name: write_tests
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - architecture
+      - unit-testing
+      - e2e-testing
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    required_permission_mode: edit
+    instruction: write-tests-first
+    rules:
+      - condition: Tests written successfully
+        next: draft
+      - condition: Cannot proceed because the test target is not implemented yet, so skip test writing
+        next: draft
+      - condition: Cannot proceed with test writing
+        next: ABORT
+      - condition: User input needed for clarification
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+    output_contracts:
+      report:
+        - name: test-report.md
+          format: test-report
+  - name: draft
+    kind: workflow_call
+    call: default-draft
+    args:
+      impl_instruction: implement-after-tests
+    rules:
+      - condition: COMPLETE
+        next: peer-review
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT
+  - name: peer-review
+    kind: workflow_call
+    call: default-peer-review
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT

--- a/.takt/workflows/frontend.yaml
+++ b/.takt/workflows/frontend.yaml
@@ -1,0 +1,459 @@
+name: frontend
+description: Frontend development workflow with test-first, AI review, 2-stage reviews, fix loops, and supervision
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 30
+initial_step: plan
+loop_monitors:
+  - cycle:
+      - ai-antipattern-review-1st
+      - ai-antipattern-fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: loop-monitor-ai-antipattern-fix
+      rules:
+        - condition: Healthy (making progress)
+          next: ai-antipattern-review-1st
+        - condition: Unproductive (no improvement)
+          next: reviewers_1
+  - cycle:
+      - reviewers_1
+      - fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: loop-monitor-reviewers-fix
+      rules:
+        - condition: converging (findings decreasing, fixes applied)
+          next: reviewers_1
+        - condition: unproductive (same findings repeating)
+          next: supervise
+steps:
+  - name: plan
+    edit: false
+    persona: planner
+    policy:
+      - design-planning
+    knowledge:
+      - frontend
+      - react
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Bash
+          - WebSearch
+          - WebFetch
+    instruction: plan
+    rules:
+      - condition: Task analysis and planning is complete
+        next: write_tests
+      - condition: Requirements are unclear and planning cannot proceed
+        next: ABORT
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan-frontend
+  - name: write_tests
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - frontend
+      - react
+      - architecture
+      - unit-testing
+      - e2e-testing
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    required_permission_mode: edit
+    instruction: write-tests-first
+    rules:
+      - condition: Test creation is complete
+        next: implement
+      - condition: Skipping test creation as target is not yet implemented
+        next: implement
+      - condition: Cannot proceed with test creation
+        next: plan
+      - condition: User input required for clarification
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+    output_contracts:
+      report:
+        - name: test-report.md
+          format: test-report
+  - name: implement
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - design-fidelity
+    session: refresh
+    knowledge:
+      - frontend
+      - react
+      - security
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    instruction: implement
+    rules:
+      - condition: Implementation is complete
+        next: ai-antipattern-review-1st
+      - condition: No implementation (report only)
+        next: ai-antipattern-review-1st
+      - condition: Cannot proceed with implementation
+        next: ai-antipattern-review-1st
+      - condition: User input required
+        next: implement
+        requires_user_input: true
+        interactive_only: true
+    output_contracts:
+      report:
+        - name: coder-scope.md
+          format: coder-scope
+        - name: coder-decisions.md
+          format: coder-decisions
+  - name: ai-antipattern-review-1st
+    edit: false
+    persona: ai-antipattern-reviewer
+    policy:
+      - review
+      - ai-antipattern
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - WebSearch
+          - WebFetch
+    instruction: ai-antipattern-review
+    rules:
+      - condition: No AI-specific issues found
+        next: reviewers_1
+      - condition: AI-specific issues detected
+        next: ai-antipattern-fix
+    output_contracts:
+      report:
+        - name: ai-antipattern-review.md
+          format: ai-antipattern-review
+  - name: ai-antipattern-fix
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - design-fidelity
+    session: refresh
+    knowledge:
+      - frontend
+      - react
+      - security
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    instruction: ai-antipattern-fix
+    pass_previous_response: false
+    rules:
+      - condition: AI Reviewer's issues have been fixed
+        next: ai-antipattern-review-1st
+      - condition: No fix needed (verified target files/spec)
+        next: ai-antipattern-no-fix
+      - condition: Unable to proceed with fixes
+        next: ai-antipattern-no-fix
+  - name: ai-antipattern-no-fix
+    edit: false
+    persona: architecture-reviewer
+    policy: review
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+    rules:
+      - condition: ai-antipattern-review-1st's findings are valid (fix required)
+        next: ai-antipattern-fix
+      - condition: ai-antipattern-fix's judgment is valid (no fix needed)
+        next: reviewers_1
+    instruction: arbitrate
+  - name: reviewers_1
+    parallel:
+      - name: arch-review
+        edit: false
+        persona: architecture-reviewer
+        policy: review
+        knowledge:
+          - architecture
+          - frontend
+          - react
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-arch
+        output_contracts:
+          report:
+            - name: architect-review.md
+              format: architecture-review
+      - name: frontend-review
+        edit: false
+        persona: frontend-reviewer
+        policy:
+          - review
+          - design-fidelity
+        knowledge:
+          - frontend
+          - react
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-frontend
+        output_contracts:
+          report:
+            - name: frontend-review.md
+              format: frontend-review
+      - name: testing-review
+        edit: false
+        persona: testing-reviewer
+        policy:
+          - review
+          - testing
+        knowledge:
+          - unit-testing
+          - e2e-testing
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-test
+        output_contracts:
+          report:
+            - name: testing-review.md
+              format: testing-review
+      - name: ai-antipattern-review-2nd
+        edit: false
+        persona: ai-antipattern-reviewer
+        policy:
+          - review
+          - ai-antipattern
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        instruction: ai-antipattern-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        output_contracts:
+          report:
+            - name: ai-antipattern-review.md
+              format: ai-antipattern-review
+    rules:
+      - condition: all("approved")
+        next: reviewers_2
+      - condition: any("needs_fix")
+        next: fix
+  - name: reviewers_2
+    parallel:
+      - name: security-review
+        edit: false
+        persona: security-reviewer
+        policy: review
+        knowledge: security
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+      - name: qa-review
+        edit: false
+        persona: qa-reviewer
+        policy:
+          - review
+          - qa
+        provider_options:
+          claude:
+            allowed_tools:
+              - Read
+              - Glob
+              - Grep
+              - WebSearch
+              - WebFetch
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-qa
+        output_contracts:
+          report:
+            - name: qa-review.md
+              format: qa-review
+    rules:
+      - condition: all("approved")
+        next: supervise
+      - condition: any("needs_fix")
+        next: fix
+  - name: fix
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - design-fidelity
+    knowledge:
+      - frontend
+      - react
+      - security
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    required_permission_mode: edit
+    pass_previous_response: false
+    rules:
+      - condition: Fix complete
+        next: reviewers_1
+      - condition: Cannot proceed, insufficient info
+        next: plan
+    instruction: fix
+  - name: supervise
+    edit: false
+    persona: dual-supervisor
+    policy: review
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - WebSearch
+          - WebFetch
+    instruction: supervise
+    pass_previous_response: false
+    rules:
+      - condition: All validations pass and ready to merge
+        next: COMPLETE
+      - condition: Issues detected during final review
+        next: fix_supervisor
+    output_contracts:
+      report:
+        - name: supervisor-validation.md
+          format: supervisor-validation
+        - name: summary.md
+          format: summary
+          use_judge: false
+  - name: fix_supervisor
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+      - design-fidelity
+    knowledge:
+      - frontend
+      - react
+      - security
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    instruction: fix-supervisor
+    pass_previous_response: false
+    rules:
+      - condition: Supervisor's issues have been fixed
+        next: supervise
+      - condition: Unable to proceed with fixes
+        next: plan

--- a/.takt/workflows/frontend.yaml
+++ b/.takt/workflows/frontend.yaml
@@ -131,9 +131,9 @@ steps:
       - condition: Implementation is complete
         next: ai-antipattern-review-1st
       - condition: No implementation (report only)
-        next: ai-antipattern-review-1st
+        next: plan
       - condition: Cannot proceed with implementation
-        next: ai-antipattern-review-1st
+        next: ABORT
       - condition: User input required
         next: implement
         requires_user_input: true

--- a/.takt/workflows/frontend.yaml
+++ b/.takt/workflows/frontend.yaml
@@ -166,7 +166,7 @@ steps:
         next: ai-antipattern-fix
     output_contracts:
       report:
-        - name: ai-antipattern-review.md
+        - name: ai-antipattern-review-1st.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
     edit: true
@@ -313,7 +313,7 @@ steps:
           - condition: needs_fix
         output_contracts:
           report:
-            - name: ai-antipattern-review.md
+            - name: ai-antipattern-review-2nd.md
               format: ai-antipattern-review
     rules:
       - condition: all("approved")


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/415#issue-4537403617

https://github.com/Hashimoto-Noriaki/next-article-share-app/issues/413#issue-4518362107

## 概要

AI エージェントのワークフロー管理ツール **TAKT** をプロジェクトに導入する。
テストファースト開発・AIアンチパターンレビュー・並列ピアレビュー・スーパーバイズを段階的に実行するワークフローを定義し、Claude Code のパーミッション設定も合わせて整備した。

## 変更内容

- `.takt/config.yaml` — プロバイダー（claude）・モデル（claude-sonnet-4-6）・言語（ja）の基本設定を追加
- `.takt/workflows/default.yaml` — plan → write_tests → draft → peer-review の汎用ワークフローを追加
- `.takt/workflows/frontend.yaml` — フロントエンド向け拡張ワークフローを追加
  - plan → write_tests → implement → AIアンチパターンレビュー（1st）→ 並列ピアレビュー（arch / frontend / testing / AI 2nd）→ セキュリティ/QAレビュー → supervise の多段構成
  - ループ監視付き（AI修正ループ・レビュー修正ループそれぞれ最大3サイクル）
  - 実装不能時（`Cannot proceed`）はレビューへ流さず `ABORT`、実装なし（`No implementation`）は `plan` へ戻す
  - 1st/2nd AIアンチパターンレビューのレポートファイル名を分離し上書き防止
- `.takt/.gitignore` — ランタイム生成物を除外し、設定・ワークフロー定義のみバージョン管理対象に設定
- `.claude/settings.json` — `takt *` コマンドを許可リストに追加、force push / `rm -rf` / `.env` 操作を拒否リストに追加

## テスト方法

- [ ] `takt workflow doctor` を実行して両ワークフローが `Workflow OK` になること
- [ ] `takt prompt default` / `takt prompt frontend` でプロンプトが正常にアセンブルされること
- [ ] `takt` を起動してワークフロー選択メニューに `default` / `frontend` が表示されること