### PR TITLE
ci: Storybookバージョンアップ対策（Dependabot自動更新 + CIビルドチェック）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
     groups:
       storybook:
         patterns:
-          - "@storybook/*"
-          - "storybook"
-          - "eslint-plugin-storybook"
+          - '@storybook/*'
+          - 'storybook'
+          - 'eslint-plugin-storybook'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+          - "eslint-plugin-storybook"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@<full-length-commit-sha>
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@<full-length-commit-sha>
+        uses: actions/setup-node@v4
         with:
           node-version: '20.19'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@<full-length-commit-sha>
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@<full-length-commit-sha>
         with:
           node-version: '20.19'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,28 @@ env:
   JWT_SECRET: 'dummy-secret-for-ci'
 
 jobs:
+  storybook:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
   ci:
     runs-on: ubuntu-latest
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,14 +1,30 @@
 import type { StorybookConfig } from '@storybook/nextjs';
+import type { Configuration } from 'webpack';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    '@storybook/addon-a11y', // ← これを追加
+    '@storybook/addon-a11y',
   ],
   framework: {
     name: '@storybook/nextjs',
     options: {},
   },
   staticDirs: ['../public'],
+  webpackFinal: async (config: Configuration) => {
+    config.resolve = {
+      ...config.resolve,
+      fallback: {
+        ...config.resolve?.fallback,
+        // pg / Prisma が依存する Node.js 組み込みモジュールをブラウザビルドで無効化
+        net: false,
+        tls: false,
+        fs: false,
+        dns: false,
+        child_process: false,
+      },
+    };
+    return config;
+  },
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,9 +3,7 @@ import type { Configuration } from 'webpack';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: [
-    '@storybook/addon-a11y',
-  ],
+  addons: ['@storybook/addon-a11y'],
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ npx playwright test
 npm run storybook
 ```
 
+### StoryBookのビルド
+
+```bash
+npm run build-storybook
+```
+
 ![スクリーンショット 2026-01-28 5 02 59](https://github.com/user-attachments/assets/14971429-0f75-47da-bb14-b66409dc84d2)
 
 詳細: [docs/ui/storybook.md](docs/ui/storybook.md)


### PR DESCRIPTION
## 概要

Storybook のバージョンアップ作業を省力化するため、以下の2点を整備した。
- **Dependabot** により新バージョンの更新 PR を毎週自動作成
- **CI** で `build-storybook` を実行しビルドエラーを自動検知

合わせて、`pg`（PostgreSQL クライアント）が Node.js 組み込みモジュールを要求することで発生していた Storybook ビルドエラーも修正した。

## 変更内容

- `.github/dependabot.yml`（新規）: `@storybook/*`・`storybook`・`eslint-plugin-storybook` を `storybook` グループとしてまとめ、毎週月曜に1本の更新 PR を自動作成
- `.github/workflows/ci.yml`: `storybook` ジョブを追加。PR のたびに `build-storybook` を実行し、既存の `ci` ジョブとは独立してビルドエラーを検知
- `.storybook/main.ts`: `webpackFinal` に `resolve.fallback` を追加し、`pg` / Prisma が依存する `net`・`tls`・`fs`・`dns`・`child_process` をブラウザビルドで無効化（`Module not found: Can't resolve 'net'` エラーの解消）
- `README.md`: Storybook セクションに `build-storybook` コマンドを追加

## テスト方法

- [ ] CI の `storybook` ジョブが成功していることを確認する
- [ ] GitHub の Settings > Code security > Dependabot で `storybook` グループの設定が認識されていることを確認する